### PR TITLE
Add SightingQueue class and corresponding tests for enqueue, dequeue, and deduplication logic

### DIFF
--- a/packages/ingest-agent/src/queue.test.ts
+++ b/packages/ingest-agent/src/queue.test.ts
@@ -36,18 +36,18 @@ describe("SightingQueue", () => {
     const s = makeSighting("42", "inaturalist");
     expect(queue.enqueue(s)).toBe(true);
     expect(queue.enqueue(s)).toBe(false);
-    // same id, different source — should be admitted
+    // same id, different source - should be admitted
     expect(queue.enqueue(makeSighting("42", "gbif"))).toBe(true);
     expect(queue.size).toBe(2);
   });
 
-  it("tracks seenIds including dequeued items", () => {
+  it("removes dequeued ids from seen so they can be re-enqueued", () => {
     queue.enqueue(makeSighting("1"));
     queue.enqueue(makeSighting("2"));
     queue.dequeue();
-    expect(queue.seenIds).toBe(2);
-    // re-enqueue dequeued id should still be rejected
-    expect(queue.enqueue(makeSighting("1"))).toBe(false);
+    expect(queue.seenIds).toBe(1);
+    // re-enqueue dequeued id - should be admitted after seen cleanup
+    expect(queue.enqueue(makeSighting("1"))).toBe(true);
   });
 
   it("enforces max capacity by dropping the oldest item", () => {
@@ -59,6 +59,8 @@ describe("SightingQueue", () => {
     queue.enqueue(makeSighting("500"));
     expect(queue.size).toBe(500);
     expect(queue.dequeue()?.id).toBe("1");
+    // evicted id "0" is removed from seen - can be enqueued again
+    expect(queue.enqueue(makeSighting("0"))).toBe(true);
   });
 
   it("peek returns a copy without mutating the queue", () => {

--- a/packages/ingest-agent/src/queue.ts
+++ b/packages/ingest-agent/src/queue.ts
@@ -17,14 +17,21 @@ export class SightingQueue {
     }
     this.seen.set(key, true);
     if (this.items.length >= MAX_CAPACITY) {
-      this.items.shift();
+      const evicted = this.items.shift();
+      if (evicted) {
+        this.seen.delete(compositeKey(evicted.source, evicted.id));
+      }
     }
     this.items.push(sighting);
     return true;
   }
 
   dequeue(): Sighting | undefined {
-    return this.items.shift();
+    const item = this.items.shift();
+    if (item) {
+      this.seen.delete(compositeKey(item.source, item.id));
+    }
+    return item;
   }
 
   peek(): Sighting[] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-memory sightings queue with FIFO ordering, deduplication by id+source, and a fixed capacity that evicts oldest entries when full.
  * Added a peek operation that returns a snapshot of queued items and runtime counters showing current size and tracked IDs.

* **Tests**
  * Added tests validating ordering, deduplication, re-enqueue behavior after dequeue, capacity eviction, and snapshot immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->