### PR TITLE
add formatter and tests for alert formatting logic

### DIFF
--- a/packages/alert-agent/src/formatter.test.ts
+++ b/packages/alert-agent/src/formatter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { ThreatLevel } from "@rangerwatch/shared";
 import type { ScoredSighting } from "@rangerwatch/shared";
+import { isAlertBoth, isAlertWebhook } from "@rangerwatch/shared";
 import { formatAlert } from "./formatter";
 
 const baseSighting: ScoredSighting = {
@@ -34,7 +35,8 @@ describe("formatAlert", () => {
 
   it("CRITICAL formattedMessage contains SMS template for sms field", () => {
     const alert = formatAlert({ ...baseSighting, threatLevel: ThreatLevel.CRITICAL });
-    const msg = alert.formattedMessage as { sms: string; webhook: string };
+    if (!isAlertBoth(alert)) throw new Error("expected AlertBoth");
+    const msg = alert.formattedMessage;
     expect(typeof msg).toBe("object");
     expect(msg.sms).toContain("CRITICAL:");
     expect(msg.sms).toContain("Immediate review required.");
@@ -42,21 +44,24 @@ describe("formatAlert", () => {
 
   it("CRITICAL formattedMessage contains webhook template for webhook field", () => {
     const alert = formatAlert({ ...baseSighting, threatLevel: ThreatLevel.CRITICAL });
-    const msg = alert.formattedMessage as { sms: string; webhook: string };
+    if (!isAlertBoth(alert)) throw new Error("expected AlertBoth");
+    const msg = alert.formattedMessage;
     expect(msg.webhook).toContain("RANGERWATCH ALERT");
     expect(msg.webhook).toContain("Species:");
   });
 
   it("INFO formattedMessage is a webhook template string", () => {
     const alert = formatAlert({ ...baseSighting, threatLevel: ThreatLevel.INFO, anomalyScore: 10 });
+    if (!isAlertWebhook(alert)) throw new Error("expected AlertWebhook");
     expect(typeof alert.formattedMessage).toBe("string");
-    expect(alert.formattedMessage as string).toContain("RANGERWATCH ALERT");
-    expect(alert.formattedMessage as string).toContain("Species:");
+    expect(alert.formattedMessage).toContain("RANGERWATCH ALERT");
+    expect(alert.formattedMessage).toContain("Species:");
   });
 
   it("SMS message (CRITICAL sms field) is under 160 characters", () => {
     const alert = formatAlert({ ...baseSighting, threatLevel: ThreatLevel.CRITICAL });
-    const sms = (alert.formattedMessage as { sms: string }).sms;
+    if (!isAlertBoth(alert)) throw new Error("expected AlertBoth");
+    const sms = alert.formattedMessage.sms;
     expect(sms.length).toBeLessThan(160);
   });
 
@@ -68,19 +73,22 @@ describe("formatAlert", () => {
       iucnStatus: "Endangered (EN)",
     };
     const alert = formatAlert(longSighting);
-    const sms = (alert.formattedMessage as { sms: string }).sms;
+    if (!isAlertBoth(alert)) throw new Error("expected AlertBoth");
+    const sms = alert.formattedMessage.sms;
     expect(sms.length).toBeLessThan(160);
   });
 
   it("CRITICAL out-of-range sighting uses 'sighted out of range at' phrasing", () => {
     const alert = formatAlert({ ...baseSighting, threatLevel: ThreatLevel.CRITICAL, inRange: false });
-    const sms = (alert.formattedMessage as { sms: string }).sms;
+    if (!isAlertBoth(alert)) throw new Error("expected AlertBoth");
+    const sms = alert.formattedMessage.sms;
     expect(sms).toContain("sighted out of range at");
   });
 
   it("CRITICAL in-range sighting uses neutral 'detected at' phrasing", () => {
     const alert = formatAlert({ ...baseSighting, threatLevel: ThreatLevel.CRITICAL, inRange: true });
-    const sms = (alert.formattedMessage as { sms: string }).sms;
+    if (!isAlertBoth(alert)) throw new Error("expected AlertBoth");
+    const sms = alert.formattedMessage.sms;
     expect(sms).toContain("detected at");
     expect(sms).not.toContain("out of range");
   });

--- a/packages/alert-agent/src/formatter.ts
+++ b/packages/alert-agent/src/formatter.ts
@@ -47,16 +47,26 @@ function buildWebhookMessage(sighting: ScoredSighting): string {
 
 export function formatAlert(sighting: ScoredSighting): Alert {
   const dispatchMethod = dispatchMethodFor(sighting.threatLevel);
-  const formattedMessage =
-    dispatchMethod === "both"
-      ? { sms: buildSmsMessage(sighting), webhook: buildWebhookMessage(sighting) }
-      : buildWebhookMessage(sighting);
-
-  return {
+  const base = {
     ...sighting,
     alertId: crypto.randomUUID(),
-    formattedMessage,
     dispatchedAt: new Date(),
-    dispatchMethod,
+  };
+
+  if (dispatchMethod === "both") {
+    return {
+      ...base,
+      dispatchMethod: "both",
+      formattedMessage: {
+        sms: buildSmsMessage(sighting),
+        webhook: buildWebhookMessage(sighting),
+      },
+    };
+  }
+
+  return {
+    ...base,
+    dispatchMethod: "webhook",
+    formattedMessage: buildWebhookMessage(sighting),
   };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -40,13 +40,41 @@ export interface ScoredSighting extends ClassifiedSighting {
   inRange: boolean;
 }
 
-export type AlertDispatchMethod = "webhook" | "sms" | "both";
-
-export interface Alert extends ScoredSighting {
+/** Shared fields on every dispatched alert. */
+export type AlertBase = ScoredSighting & {
   alertId: string;
-  formattedMessage: string | { sms: string; webhook: string };
   dispatchedAt: Date;
-  dispatchMethod: AlertDispatchMethod;
+};
+
+export interface AlertSms extends AlertBase {
+  dispatchMethod: "sms";
+  formattedMessage: string;
+}
+
+export interface AlertWebhook extends AlertBase {
+  dispatchMethod: "webhook";
+  formattedMessage: string;
+}
+
+export interface AlertBoth extends AlertBase {
+  dispatchMethod: "both";
+  formattedMessage: { sms: string; webhook: string };
+}
+
+export type Alert = AlertSms | AlertWebhook | AlertBoth;
+
+export type AlertDispatchMethod = Alert["dispatchMethod"];
+
+export function isAlertSms(alert: Alert): alert is AlertSms {
+  return alert.dispatchMethod === "sms";
+}
+
+export function isAlertWebhook(alert: Alert): alert is AlertWebhook {
+  return alert.dispatchMethod === "webhook";
+}
+
+export function isAlertBoth(alert: Alert): alert is AlertBoth {
+  return alert.dispatchMethod === "both";
 }
 
 export interface GuardrailResult {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alerts now provide channel-aware formatted content: either a single webhook message or separate SMS and webhook messages.
  * Dispatch method is chosen automatically by threat severity; critical alerts are sent via both SMS and webhook.
  * SMS wording changes depending on whether a sighting is in-range or out-of-range; SMS length kept under 160 characters.

* **Tests**
  * Added tests validating message formats, dispatch selection, content structure and SMS length limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->